### PR TITLE
extended_valid_elements eingefuegt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Beispiel:
     // Add a content_css in tinymce editor
     $GLOBALS['TINYMCE']['SETTINGS']['CONTENT_CSS'][] = 'my_plugin.css';
 
+    // Add a ,'extended_valid_elements' in tinymce editor z.B. for fontawesome
+    $GLOBALS['TINYMCE']['SETTINGS']['EXTENDED_VALID_ELEMENTS'][] = 'i[*]';
+
     // Ein eigener Schlüssel wird durch
     $GLOBALS['TINYMCE']['SETTINGS']['CONFIG_ROW']['myKey'] = 'myKeyValue';
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Beispiel:
     // Add a content_css in tinymce editor
     $GLOBALS['TINYMCE']['SETTINGS']['CONTENT_CSS'][] = 'my_plugin.css';
 
-    // Add a ,'extended_valid_elements' in tinymce editor z.B. for fontawesome
+    // Add 'extended_valid_elements' to tinymce editor e.g. Font Awesome
     $GLOBALS['TINYMCE']['SETTINGS']['EXTENDED_VALID_ELEMENTS'][] = 'i[*]';
 
     // Ein eigener Schlüssel wird durch

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -38,7 +38,7 @@ class ParseTemplateListener
 
         $this->strBuffer = $strBuffer;
 
-        $arrKeys = ['plugins', 'toolbar', 'content_css'];
+        $arrKeys = ['plugins', 'toolbar', 'content_css','extended_valid_elements'];
 
         foreach ($arrKeys as $key) {
             $regexMatch = sprintf(self::REGEX_MATCH, $key);
@@ -91,7 +91,9 @@ class ParseTemplateListener
                         }
 
                         // content_css
-                        if ('content_css' === $key) {
+                        //if ('content_css' === $key) {
+                        // content_css extended_valid_elements  komma separated
+                        if ('content_css' === $key || 'extended_valid_elements' === $key) {
                             // Plugins are separated by commas
                             $aPlugins = preg_split('/\\s*,\\s*/', $oldValue);
 

--- a/src/EventListener/ParseTemplateListener.php
+++ b/src/EventListener/ParseTemplateListener.php
@@ -38,7 +38,7 @@ class ParseTemplateListener
 
         $this->strBuffer = $strBuffer;
 
-        $arrKeys = ['plugins', 'toolbar', 'content_css','extended_valid_elements'];
+        $arrKeys = ['plugins', 'toolbar', 'content_css', 'extended_valid_elements'];
 
         foreach ($arrKeys as $key) {
             $regexMatch = sprintf(self::REGEX_MATCH, $key);
@@ -91,8 +91,8 @@ class ParseTemplateListener
                         }
 
                         // content_css
-                        //if ('content_css' === $key) {
-                        // content_css extended_valid_elements  komma separated
+                        // if ('content_css' === $key) {
+                        // content_css extended_valid_elements  comma separated
                         if ('content_css' === $key || 'extended_valid_elements' === $key) {
                             // Plugins are separated by commas
                             $aPlugins = preg_split('/\\s*,\\s*/', $oldValue);


### PR DESCRIPTION
Hallo Marko
bitte uebernehmen, damit wird es erst möglich eigene Blöcke einzufuegen.
z.B von fontawesome
in config 
    $GLOBALS['TINYMCE']['SETTINGS']['EXTENDED_VALID_ELEMENTS'][] = 'i[*]';

damit wird der Teil auch in den Code uebernommen
<i class="fab fa-accessible-icon fa-3x " style="color: #fa0707;"></i>
LG
Peter